### PR TITLE
Fix getRunEnergy() returning too fine values

### DIFF
--- a/TScripts/src/main/java/net/runelite/client/plugins/tscripts/api/definitions/GLocalPlayer.java
+++ b/TScripts/src/main/java/net/runelite/client/plugins/tscripts/api/definitions/GLocalPlayer.java
@@ -56,7 +56,7 @@ public class GLocalPlayer implements GroupDefinition
         );
         addMethod(methods, "getRunEnergy", Type.INT,
                 ImmutableMap.of(),
-                function -> Static.getClient().getEnergy(),
+                function -> Static.getClient().getEnergy() / 100,
                 "Returns the run energy of the local player"
         );
         addMethod(methods, "runEnabled", Type.INT,


### PR DESCRIPTION
its returning values which are not the UI values

![image](https://github.com/Tonic-Box/TScriptsRepository/assets/2548763/7c91fd87-d85a-429a-9838-7f20287d001a)

114 = 1.14%
133 = 1.33% 

etc...